### PR TITLE
sprout: fix

### DIFF
--- a/sprout/Android.mk
+++ b/sprout/Android.mk
@@ -14,7 +14,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter sprout4 sprout8, $(TARGET_DEVICE)),)
+ifneq ($(filter sprout4 sprout8 sprout sprout_b, $(TARGET_DEVICE)),)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libaudiopolicymanager


### PR DESCRIPTION
Get an error with libaudiopolicymanager if I go back to original names in device tree, i.e. sprout and sprout_b
This fixes it
