### PR TITLE
floral: proprietary-files: Drop RefreshRate app

### DIFF
--- a/coral/Android.bp
+++ b/coral/Android.bp
@@ -428,18 +428,6 @@ android_app_import {
 }
 
 android_app_import {
-	name: "RefreshRateControl",
-	owner: "google",
-	apk: "proprietary/product/priv-app/RefreshRateControl/RefreshRateControl.apk",
-	certificate: "platform",
-	dex_preopt: {
-		enabled: false,
-	},
-	privileged: true,
-	product_specific: true,
-}
-
-android_app_import {
 	name: "RilConfigService",
 	owner: "google",
 	apk: "proprietary/product/priv-app/RilConfigService/RilConfigService.apk",


### PR DESCRIPTION
* AOSP handles this /fine enough/, over 70% brightness
  it scales to 90hz, under 70% it scaled back to 60hz.

* As of now this app crashes on repeat, and when appease
  to not crash, it causes display flickering.

Change-Id: I17a51a64b1b4aee9ad4aec55d3a295f351c1f7ac